### PR TITLE
refac: Update Datil-dev contracts deployment date for General Worker

### DIFF
--- a/apps/lit-general-worker/src/handlers/contracts-handler/contractsHandler.ts
+++ b/apps/lit-general-worker/src/handlers/contracts-handler/contractsHandler.ts
@@ -279,7 +279,7 @@ contractsHandler.get("/", (req, res) => {
         SERRANO_CONTRACTS_JSON,
         INTERNAL_CONTRACTS_JSON,
 
-        // Added on 26 June 2024
+        // Added on 22 July 2024
         DATILDEV_CONTRACTS_JSON,
 
         // Added on 4 July 2024


### PR DESCRIPTION
Since the contracts are pulled by the automatically by the General Worker from the networks repo just update the date in the comments